### PR TITLE
fix: pin trivy-action to commit SHA to mitigate supply chain attack

### DIFF
--- a/.github/workflows/full-pipeline.yaml
+++ b/.github/workflows/full-pipeline.yaml
@@ -92,7 +92,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         image-ref: 'ghcr.io/${{ env.IMAGE }}:latest'
         format: 'table'

--- a/pipelines/02-complete.yaml
+++ b/pipelines/02-complete.yaml
@@ -111,7 +111,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         image-ref: 'ghcr.io/${{ env.IMAGE }}:latest'
         format: 'table'

--- a/pipelines/03-complete.yaml
+++ b/pipelines/03-complete.yaml
@@ -156,7 +156,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         image-ref: 'ghcr.io/${{ env.IMAGE }}:latest'
         format: 'table'

--- a/pipelines/04-complete.yaml
+++ b/pipelines/04-complete.yaml
@@ -155,7 +155,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         image-ref: 'ghcr.io/${{ env.IMAGE }}:latest'
         format: 'table'

--- a/pipelines/05-complete.yaml
+++ b/pipelines/05-complete.yaml
@@ -178,7 +178,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
         image-ref: 'ghcr.io/${{ env.IMAGE }}:latest'
         format: 'table'


### PR DESCRIPTION
## Summary
- Pins `aquasecurity/trivy-action` from `@master` to `@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0) across all 5 workflow files
- Mitigates the [trivy-action supply chain compromise](https://www.bleepingcomputer.com/news/security/trivy-vulnerability-scanner-breach-pushed-infostealer-via-github-actions/) where the `master` tag was modified to inject an infostealer that exfiltrates CI secrets
- Using a commit SHA (not a tag) ensures the reference is immutable

## Files changed
- `.github/workflows/full-pipeline.yaml`
- `pipelines/02-complete.yaml`
- `pipelines/03-complete.yaml`
- `pipelines/04-complete.yaml`
- `pipelines/05-complete.yaml`

## Test plan
- [ ] Verify CI workflows still run successfully with the pinned version